### PR TITLE
Fix for locked head rotation in mp.

### DIFF
--- a/Code/GameSDK/GameDll/Player.cpp
+++ b/Code/GameSDK/GameDll/Player.cpp
@@ -2283,7 +2283,12 @@ void CPlayer::SetIK( const SActorFrameMovementParams& frameMovementParams )
 	{
 		if (IsThirdPerson()) 
 		{
-			const Vec3 cameraPosition = GetViewMatrix().GetTranslation();
+			Vec3 cameraPosition;
+
+			if (IsClient())
+				cameraPosition = GetViewMatrix().GetTranslation();
+			else
+				cameraPosition = curMovementState.eyePosition;
 
 			const Vec3 down = Vec3(0, 0, -1);
 			const float dotProd = curMovementState.aimDirection.dot(down);


### PR DESCRIPTION
Added destinction between local and remote clients so the head rotation of remote clients isn´t locked towards 0,0,0.
The view matrix is ofc always invalid for remote clients so the raycast returns a collison with terrain at 0,0,0 making the head always point in that direction.
Also maybe consider specifying IsClient seperately and outside of IsThirdPerson since it can lead to confusion.
