### PR TITLE
!B (CWE-806) (3DEngine) buffer underflow fixed by PVS-Studio

### DIFF
--- a/Code/CryEngine/Cry3DEngine/GeomCacheRenderNode.cpp
+++ b/Code/CryEngine/Cry3DEngine/GeomCacheRenderNode.cpp
@@ -282,7 +282,7 @@ void CGeomCacheRenderNode::Render(const struct SRendParams& rendParams, const SR
 												(uint8)std::distance(meshData.m_instances.begin(),                 &instance)
 											};
 
-											memcpy(hashableData, pCREGeomCache, sizeof(pCREGeomCache));
+											memcpy(hashableData, pCREGeomCache, sizeof(*pCREGeomCache));
 											pRenderObjData->m_uniqueObjectId = static_cast<uintptr_t>(XXH64(hashableData, sizeof(hashableData), 0)) + reinterpret_cast<uintptr_t>(this);
 
 											pCREGeomCache->SetupMotionBlur(pInstanceRenderObject, passInfo);


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warning: V512 A call of the 'memcpy' function will lead to underflow of the buffer 'hashableData'. GeomCacheRenderNode.cpp 285