### PR TITLE
!B (CWE-467) (3DEngine) PVS-Studio: sizeof () evaluates the size of a pointer

### DIFF
--- a/Code/CryEngine/Cry3DEngine/ClipVolumeManager.cpp
+++ b/Code/CryEngine/Cry3DEngine/ClipVolumeManager.cpp
@@ -142,7 +142,7 @@ CClipVolume* CClipVolumeManager::GetClipVolumeByPos(const Vec3& pos, const IClip
 
 void CClipVolumeManager::GetMemoryUsage(class ICrySizer* pSizer) const
 {
-	pSizer->AddObject(this, sizeof(this));
+	pSizer->AddObject(this, sizeof(*this));
 	for (size_t i = 0; i < m_ClipVolumes.size(); ++i)
 		pSizer->AddObject(m_ClipVolumes[i].m_pVolume);
 }


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warning: V568 It's odd that 'sizeof()' operator evaluates the size of a pointer to a class, but not the size of the 'this' class object. ClipVolumeManager.cpp 145