### PR TITLE
!B (CWE-571) (CryPlugins) PVS-Studio: Expression is Always True

### DIFF
--- a/Code/CryPlugins/CryDefaultEntities/Module/Lights/LightEntity.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/Lights/LightEntity.h
@@ -121,7 +121,7 @@ public:
 
 	void SetActive(bool bActive)
 	{
-		if (bActive == bActive)
+		if (m_bActive == bActive)
 			return;
 
 		m_bActive = bActive;


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warning: V501 There are identical sub-expressions to the left and to the right of the '==' operator: bActive == bActive LightEntity.h 124