### PR TITLE
!B (CWE-476) (Movie) PVS-Studio: NULL Pointer Dereference

### DIFF
--- a/Code/CryEngine/CryMovie/AudioNode.cpp
+++ b/Code/CryEngine/CryMovie/AudioNode.cpp
@@ -57,11 +57,12 @@ void CAudioNode::Animate(SAnimContext& animContext)
 		const CAnimParamType paramType = m_tracks[paramIndex]->GetParameterType();
 		IAnimTrack* pTrack = m_tracks[paramIndex];
 
-		const bool bMuted = gEnv->IsEditor() && (pTrack->GetFlags() & IAnimTrack::eAnimTrackFlags_Muted);
 		if (!pTrack || pTrack->GetNumKeys() == 0 || pTrack->GetFlags() & IAnimTrack::eAnimTrackFlags_Disabled)
 		{
 			continue;
 		}
+    
+		const bool bMuted = gEnv->IsEditor() && (pTrack->GetFlags() & IAnimTrack::eAnimTrackFlags_Muted);
 
 		switch (paramType.GetType())
 		{


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warning: V595 The 'pTrack' pointer was utilized before it was verified against nullptr. Check lines: 60, 61. AudioNode.cpp 60