### PR TITLE
!B (CWE-688) (3DEngine) PVS-Studio: Function Call With Incorrect Variable

### DIFF
--- a/Code/CryEngine/Cry3DEngine/ObjectsTree_Serialize.cpp
+++ b/Code/CryEngine/Cry3DEngine/ObjectsTree_Serialize.cpp
@@ -1132,7 +1132,7 @@ void COctreeNode::LoadSingleObject(byte*& pPtr, std::vector<IStatObj*>* pStatObj
 		int auxCntSrc = pChunk->m_volumeTypeAndMiscBits >> volumeTypeAndMiscBitShift, auxCntDst;
 		float* pAuxDataDst = pObj->GetAuxSerializationDataPtr(auxCntDst);
 		const float* pAuxDataSrc = StepData<float>(pPtr, auxCntSrc, eEndian);
-		memcpy(pAuxDataDst, pAuxDataDst, min(auxCntSrc, auxCntDst) * sizeof(float));
+		memcpy(pAuxDataDst, pAuxDataSrc, min(auxCntSrc, auxCntDst) * sizeof(float));
 
 		// read common node data
 		pObj->SetBBox(pChunk->m_WSBBox);


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warning: V549 The first argument of 'memcpy' function is equal to the second argument. ObjectsTree_Serialize.cpp 1135