### PR TITLE
!TE (CMake) (uniflare) Allow VS to locate CryCommon includes

### DIFF
--- a/Code/CryEngine/CryAudioSystem/Common/CMakeLists.txt
+++ b/Code/CryEngine/CryAudioSystem/Common/CMakeLists.txt
@@ -18,3 +18,10 @@ end_sources()
 #END-FILE-LIST
 
 CryFileContainer(CryAudioCommon SOLUTION_FOLDER "CryEngine/Audio")
+
+# Only for VS
+if (${CMAKE_GENERATOR} MATCHES "^Visual Studio")
+	# Fix to add CryCommon includes in VS ide
+	configure_file ("CryAudioCommon.vcxproj.user.in" "${CMAKE_CURRENT_BINARY_DIR}/CryAudioCommon.vcxproj.user")
+	configure_file ("CryAudioCommon.props" "${CMAKE_CURRENT_BINARY_DIR}/CryAudioCommon.props")
+endif()

--- a/Code/CryEngine/CryAudioSystem/Common/CryAudioCommon.props
+++ b/Code/CryEngine/CryAudioSystem/Common/CryAudioCommon.props
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup> 
+    <IncludePath>${CRYENGINE_DIR}\Code\CryEngine\CryCommon;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup />
+  <ItemGroup />
+</Project>

--- a/Code/CryEngine/CryAudioSystem/Common/CryAudioCommon.vcxproj.user.in
+++ b/Code/CryEngine/CryAudioSystem/Common/CryAudioCommon.vcxproj.user.in
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Add the required CryCommon include directories to this project -->
+  <Import Project="CryAudioCommon.props" />
+  
+</Project>

--- a/Code/CryEngine/CryCommon/CMakeLists.txt
+++ b/Code/CryEngine/CryCommon/CMakeLists.txt
@@ -848,6 +848,13 @@ end_sources()
 
 CryFileContainer(CryCommon SOLUTION_FOLDER Common)
 
+# Only for VS
+if (${CMAKE_GENERATOR} MATCHES "^Visual Studio")
+	# Fix to add CryCommon includes in VS ide
+	configure_file ("CryCommon.vcxproj.user.in" "${CMAKE_CURRENT_BINARY_DIR}/CryCommon.vcxproj.user")
+	configure_file ("CryCommon.props" "${CMAKE_CURRENT_BINARY_DIR}/CryCommon.props")
+endif()
+
 macro(install_headers)
 	foreach(dir ${ARGN})
 		install(DIRECTORY ${dir} DESTINATION include/CryCommon)
@@ -860,4 +867,3 @@ install_headers(CryFlowGraph CryFont CryGame CryInput CryLiveCreate CryLobby Cry
 install_headers(CryMemory CryMono CryMovie CryNetwork CryParticleSystem CryPhysics)
 install_headers(CryRenderer CrySandbox CryScriptSystem CrySerialization CryString)
 install_headers(CrySystem CryThreading)
-

--- a/Code/CryEngine/CryCommon/CryCommon.props
+++ b/Code/CryEngine/CryCommon/CryCommon.props
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup> 
+    <IncludePath>${CRYENGINE_DIR}\Code\CryEngine\CryCommon;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup />
+  <ItemGroup />
+</Project>

--- a/Code/CryEngine/CryCommon/CryCommon.vcxproj.user.in
+++ b/Code/CryEngine/CryCommon/CryCommon.vcxproj.user.in
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Add the required CryCommon include directories to this project -->
+  <Import Project="CryCommon.props" />
+  
+</Project>


### PR DESCRIPTION
*Should allow visual studio to successfully locate CryCommon includes from following CryCommon and CryAudioCommon source file include directives.

Uses configured VS project user files that include configured VS property sheet files respectively. These sheets simply add the CryCommon disk path to the project' additional include directories.

Visual studio still has some issues with certain includes from certain source files for an unknown reason.
?Expected bug from using VS Property sheets in user files?