### PR TITLE
(MonoRuntime) A Potential startup crash and exit crash.

### DIFF
--- a/Code/CryManaged/CryMonoBridge/MonoRuntime.cpp
+++ b/Code/CryManaged/CryMonoBridge/MonoRuntime.cpp
@@ -123,6 +123,7 @@ bool CMonoRuntime::Initialize(SSystemGlobalEnvironment& env, const SSystemInitPa
 	if (!gEnv->pCryPak->IsFileExist(sMonoLib) || !gEnv->pCryPak->IsFileExist(sMonoEtc))
 	{
 		CryLogAlways("Failed to initialize Mono runtime, Mono directory was not found or incomplete in %s directory", szMonoDirectoryParent);
+		Shutdown();
 		delete this;
 
 		return false;

--- a/Code/CryManaged/CryMonoBridge/MonoRuntime.cpp
+++ b/Code/CryManaged/CryMonoBridge/MonoRuntime.cpp
@@ -124,7 +124,7 @@ bool CMonoRuntime::Initialize(SSystemGlobalEnvironment& env, const SSystemInitPa
 	{
 		CryLogAlways("Failed to initialize Mono runtime, Mono directory was not found or incomplete in %s directory", szMonoDirectoryParent);
 		Shutdown();
-		delete this;
+		//delete this;
 
 		return false;
 	}


### PR DESCRIPTION
**Symptoms:**
Application crash on startup.

**Immediate Cause:**
`CSystemEventDispatcher::OnSystemEvent` tries to access invalid memory - `CMonoRuntime` - during the `ESYSTEM_PRE_RENDERER_INIT` dispatch.

**Root Cause:**
If `CMonoRuntime::Initialize` fails to find the required Mono Runtime files it deletes itself without cleaning up. Thus registered listeners are deleted without being unregistered cause access violations later on.

**Solution:**
Use the `CMonoRuntime::Shutdown` method to clean up any loose ends that it can before deleting itself.