### PR TITLE
(Various) Exit crashes.

### DIFF
--- a/Code/CryEngine/CryCommon/CrySystem/ISystem.h
+++ b/Code/CryEngine/CryCommon/CrySystem/ISystem.h
@@ -1712,11 +1712,11 @@ public:
 	}
 };
 
-	#define LOADING_TIME_PROFILE_SECTION CSYSBootProfileBlock _profileBlockLine(gEnv->pSystem, __FUNC__);
-	#define LOADING_TIME_PROFILE_SECTION_ARGS(args)                    CSYSBootProfileBlock _profileBlockLine_args(gEnv->pSystem, __FUNC__, args);
-	#define LOADING_TIME_PROFILE_SECTION_NAMED(sectionName)            CSYSBootProfileBlock _profileBlockLine_named(gEnv->pSystem, sectionName);
-	#define LOADING_TIME_PROFILE_SECTION_NAMED_ARGS(sectionName, args) CSYSBootProfileBlock _profileBlockLine_named_args(gEnv->pSystem, sectionName, args);
-	#define LOADING_TIME_PROFILE_AUTO_SESSION(sessionName)             CSYSBootProfileAutoSession _profileAutoSession(gEnv->pSystem, (sessionName));
+	#define LOADING_TIME_PROFILE_SECTION                               if(gEnv) CSYSBootProfileBlock _profileBlockLine(gEnv->pSystem, __FUNC__);
+	#define LOADING_TIME_PROFILE_SECTION_ARGS(args)                    if(gEnv) CSYSBootProfileBlock _profileBlockLine_args(gEnv->pSystem, __FUNC__, args);
+	#define LOADING_TIME_PROFILE_SECTION_NAMED(sectionName)            if(gEnv) CSYSBootProfileBlock _profileBlockLine_named(gEnv->pSystem, sectionName);
+	#define LOADING_TIME_PROFILE_SECTION_NAMED_ARGS(sectionName, args) if(gEnv) CSYSBootProfileBlock _profileBlockLine_named_args(gEnv->pSystem, sectionName, args);
+	#define LOADING_TIME_PROFILE_AUTO_SESSION(sessionName)             if(gEnv) CSYSBootProfileAutoSession _profileAutoSession(gEnv->pSystem, (sessionName));
 
 #else
 

--- a/Code/CryEngine/CrySystem/Log.cpp
+++ b/Code/CryEngine/CrySystem/Log.cpp
@@ -1175,7 +1175,7 @@ void CLog::CreateBackupFile() const
 	else
 		cry_strcpy(szPath, path);
 
-	if (!gEnv->pCryPak)
+	if (!gEnv || !gEnv->pCryPak)
 	{
 		return;
 	}

--- a/Code/CryEngine/RenderDll/Common/RenderMesh.cpp
+++ b/Code/CryEngine/RenderDll/Common/RenderMesh.cpp
@@ -4223,6 +4223,9 @@ void CRenderMesh::UpdateModified()
 // Mesh garbage collector
 void CRenderMesh::Tick(uint numFrames)
 {
+	assert(gRenDev->m_pRT != nullptr);
+	if (!gRenDev->m_pRT)
+		return;
 	MEMORY_SCOPE_CHECK_HEAP();
 	ASSERT_IS_RENDER_THREAD(gRenDev->m_pRT)
 		bool bKeepSystem = false;


### PR DESCRIPTION
3 nullptr uses during shutdown phase causes a crash.
Skip if specific pointers are null.