### PR TITLE
!FE (ProjectManager) (uniflare) Allow project file inside asset dir

### DIFF
--- a/Code/CryEngine/CrySystem/ProjectManager/ProjectManager.cpp
+++ b/Code/CryEngine/CrySystem/ProjectManager/ProjectManager.cpp
@@ -112,6 +112,18 @@ void CProjectManager::ParseProjectFile()
 	{
 		m_project.rootDirectory = PathUtil::RemoveSlash(PathUtil::ToUnixPath(PathUtil::GetPathWithoutFilename(m_project.filePath)));
 
+		// In-Asset Project File
+		//
+		// Allows specifying a project file inside the actual project Asset folder.
+		// Inside the project file, specify "." for [content]=>[assets].
+		if (m_project.assetDirectory == ".")
+		{
+			size_t lastSepPos = m_project.rootDirectory.find_last_of('/');
+			m_project.assetDirectory = m_project.rootDirectory.Right(m_project.rootDirectory.length()- lastSepPos -1);
+			m_project.rootDirectory.Truncate(lastSepPos);
+		}
+		// ~/In-Asset Project File
+
 		// Create the full path to the asset directory
 		m_project.assetDirectoryFullPath = PathUtil::Make(m_project.rootDirectory, m_project.assetDirectory);
 


### PR DESCRIPTION
By placing the project file inside the assets directory and specifying "." as the [content]=>[assets] value the plugin manager will assume the parent directory as the root, and the current as the assets directory (relative to the project file). (optional).