### PR TITLE
!R (CMake/CryRun) CMakeLists detection additions

### DIFF
--- a/Tools/CMake/Configure.cmake
+++ b/Tools/CMake/Configure.cmake
@@ -65,8 +65,13 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
 	set(OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY}_release)
 endif()
 
-set(METADATA_PROJECT_NAME "CryEngine" CACHE STRING "Name of the solution project")
-project(${METADATA_PROJECT_NAME}_CMake_${BUILD_PLATFORM} CXX C)
+if(CE_EXTENSION_NAME)
+	set(METADATA_PROJECT_NAME "${CE_EXTENSION_NAME}" CACHE STRING "Name of the solution project" FORCE)
+	project(${METADATA_PROJECT_NAME} CXX C)
+else()
+	set(METADATA_PROJECT_NAME "CryEngine" CACHE STRING "Name of the solution project")
+	project(${METADATA_PROJECT_NAME}_CMake_${BUILD_PLATFORM} CXX C)
+endif()
 
 # Prefix all Visual Studio solution folder names with this string
 set( VS_FOLDER_PREFIX "CRYENGINE/" )


### PR DESCRIPTION
!B (CMake/CryRun) Fixed corruption due to source-less default project
!T (CMake/CryRun) Always generate CMakeLists (even if no sources present)
!T (CMake/Configure) CE_EXTENSION_NAME overrides solution name
!E uniflare

Added ability to rename generated solution file by setting the cmake variable "CE_EXTENSION_NAME" before including configure.cmake.
Added Auto Detection: Project name / Solution folder (via, ${ProjectName}/CryFileContainer/project/CryEngineModule).
Added Auto Detection: Module Type (no source = hidden project. only .h = CryFileContainer. at least one .cpp = CryEngineModule).
Added Detection: Set CMake variable 'CE_EXTENSION_NAME' before including Configure.cmake to override output solution name.