### PR TITLE
!R (CryPluginManager) Allow specifying (un)load priority.

### DIFF
--- a/Code/CryEngine/CryCommon/CrySystem/ICryPlugin.h
+++ b/Code/CryEngine/CryCommon/CrySystem/ICryPlugin.h
@@ -25,6 +25,15 @@ struct IPluginUpdateListener
 
 struct ICryPlugin : public ICryUnknown, IPluginUpdateListener, IAutoCleanup
 {
+	friend class CCryPluginManager;
+
+	enum EPluginPriority : int16
+	{
+		EPluginPriority_CryUnload = -100,	// Lowest priority
+		EPluginPriority_Default = 0,
+		EPluginPriority_CryLoad = 100	// Highest priority
+	};
+
 	CRYINTERFACE_DECLARE(ICryPlugin, 0xF491A0DB38634FCA, 0xB6E6BCFE2D98EEA2);
 
 	virtual ~ICryPlugin() {}
@@ -48,6 +57,8 @@ struct ICryPlugin : public ICryUnknown, IPluginUpdateListener, IAutoCleanup
 protected:
 	uint8 m_updateFlags = IPluginUpdateListener::EUpdateType_NoUpdate;
 	std::vector<TFlowNodeTypeId> m_registeredFlowNodeIds;
+	int16 m_loadPriority = EPluginPriority_Default;
+	int16 m_unloadPriority = EPluginPriority_Default;
 };
 
 #ifndef _LIB

--- a/Code/CryEngine/CrySchematyc/Core/Impl/Core.cpp
+++ b/Code/CryEngine/CrySchematyc/Core/Impl/Core.cpp
@@ -70,7 +70,10 @@ CCore::CCore()
 	, m_pLogRecorder(new CLogRecorder())
 	, m_pSettingsManager(new CSettingsManager())
 	, m_pUpdateScheduler(new CUpdateScheduler())
-{}
+{
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload+2;
+}
 
 CCore::~CCore()
 {

--- a/Code/CryEngine/CrySchematyc/STDEnv/Impl/STDEnv.cpp
+++ b/Code/CryEngine/CrySchematyc/STDEnv/Impl/STDEnv.cpp
@@ -28,11 +28,11 @@ inline bool WantUpdate()
 } // Anonymous
 
 CSTDEnv::CSTDEnv()
-	: m_pSystemStateMonitor(new CSystemStateMonitor())
-	, m_pEntityObjectClassRegistry(new CEntityObjectClassRegistry())
-	, m_pEntityObjectMap(new CEntityObjectMap())
-	, m_pEntityObjectDebugger(new CEntityObjectDebugger())
-{}
+{
+
+	m_loadPriority = EPluginPriority_CryLoad-1; // Need to load after core
+	m_unloadPriority = EPluginPriority_CryUnload+1; // Need to die after core, before others
+}
 
 CSTDEnv::~CSTDEnv()
 {
@@ -56,6 +56,11 @@ bool CSTDEnv::Initialize(SSystemGlobalEnvironment& env, const SSystemInitParams&
 	SCHEMATYC_CORE_ASSERT(!s_pInstance);
 
 	s_pInstance = this;
+
+	m_pSystemStateMonitor = std::unique_ptr<CSystemStateMonitor>(new CSystemStateMonitor());
+	m_pEntityObjectClassRegistry = std::unique_ptr<CEntityObjectClassRegistry>(new CEntityObjectClassRegistry());
+	m_pEntityObjectMap = std::unique_ptr<CEntityObjectMap>(new CEntityObjectMap());
+	m_pEntityObjectDebugger = std::unique_ptr<CEntityObjectDebugger>(new CEntityObjectDebugger());
 
 	gEnv->pSystem->GetISystemEventDispatcher()->RegisterListener(this,"CSTDEnv");
 

--- a/Code/CryEngine/CrySystem/ExtensionSystem/CryPluginManager.cpp
+++ b/Code/CryEngine/CrySystem/ExtensionSystem/CryPluginManager.cpp
@@ -333,15 +333,15 @@ bool CCryPluginManager::OnPluginLoaded()
 bool CCryPluginManager::UnloadAllPlugins()
 {
 	bool bError = false;
-	for (SPluginContainer& it : m_pluginContainer)
+	for (auto r_it = std::rbegin(m_pluginContainer); r_it != std::rend(m_pluginContainer); ++r_it)
 	{
-		if (!it.Shutdown())
+		if (!(*r_it).Shutdown())
 		{
 			bError = true;
 		}
 
 		// notification to listeners, that plugin got un-initialized
-		NotifyEventListeners(it.m_pluginClassId, IPluginEventListener::EPluginEvent::Unloaded);
+		NotifyEventListeners((*r_it).m_pluginClassId, IPluginEventListener::EPluginEvent::Unloaded);
 	}
 
 	m_pluginContainer.clear();

--- a/Code/CryEngine/CrySystem/ExtensionSystem/CryPluginManager.h
+++ b/Code/CryEngine/CrySystem/ExtensionSystem/CryPluginManager.h
@@ -30,7 +30,7 @@ public:
 		}
 	}
 
-	// Called by CrySystem during early init to initialize the manager and load plugins
+	// Called by CrySystem during early init to initialize the manager and load plugin modules
 	// Plugins that require later activation can do so by listening to system events such as ESYSTEM_EVENT_PRE_RENDERER_INIT
 	void LoadProjectPlugins();
 
@@ -39,6 +39,7 @@ public:
 	virtual void OnSystemEvent(ESystemEvent event, UINT_PTR wparam, UINT_PTR lparam) override;
 
 protected:
+	bool 								LoadModule(EPluginType type, const char* path);
 	virtual bool                        LoadPluginFromDisk(EPluginType type, const char* path) override;
 
 	virtual std::shared_ptr<ICryPlugin> QueryPluginById(const CryClassID& classID) const override;

--- a/Code/CryPlugins/CryDefaultEntities/Module/PluginDll.cpp
+++ b/Code/CryPlugins/CryDefaultEntities/Module/PluginDll.cpp
@@ -63,6 +63,12 @@ public:
 
 CSystemEventListener g_listener;
 
+CPlugin_CryDefaultEntities::CPlugin_CryDefaultEntities()
+{
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload;
+};
+
 bool CPlugin_CryDefaultEntities::Initialize(SSystemGlobalEnvironment& env, const SSystemInitParams& initParams)
 {
 	env.pSystem->GetISystemEventDispatcher()->RegisterListener(&g_listener,"CCryPluginManager::CSystemEventListener");

--- a/Code/CryPlugins/CryDefaultEntities/Module/PluginDll.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/PluginDll.h
@@ -19,6 +19,8 @@ class CPlugin_CryDefaultEntities
 	virtual ~CPlugin_CryDefaultEntities() {}
 
 public:
+	CPlugin_CryDefaultEntities();
+
 	//! Retrieve name of plugin.
 	virtual const char* GetName() const override { return "CryDefaultEntities"; }
 

--- a/Code/CryPlugins/CryLobby/Module/CryLobbyDLL.cpp
+++ b/Code/CryPlugins/CryLobby/Module/CryLobbyDLL.cpp
@@ -12,11 +12,16 @@
 class CEngineModule_CryLobby : public ILobbyEngineModule
 {
 	CRYINTERFACE_BEGIN()
-		CRYINTERFACE_ADD(Cry::IDefaultModule)
-		CRYINTERFACE_ADD(ILobbyEngineModule)
+	CRYINTERFACE_ADD(Cry::IDefaultModule)
+	CRYINTERFACE_ADD(ILobbyEngineModule)
 	CRYINTERFACE_END()
 	CRYGENERATE_SINGLETONCLASS(CEngineModule_CryLobby, "EngineModule_CryLobby", 0x2c5cc5ec41f7451c, 0xa785857ca7731c28)
 
+	CEngineModule_CryLobby()
+	{
+		m_loadPriority = EPluginPriority_CryLoad;
+		m_unloadPriority = EPluginPriority_CryUnload;
+	}
 	virtual ~CEngineModule_CryLobby()
 	{
 		SAFE_DELETE(gEnv->pLobby);

--- a/Code/CryPlugins/CrySensorSystem/Module/CrySensorSystemPluginDLL.cpp
+++ b/Code/CryPlugins/CrySensorSystem/Module/CrySensorSystemPluginDLL.cpp
@@ -8,6 +8,12 @@
 
 #include "SensorSystem.h"
 
+CCrySensorSystemPlugin::CCrySensorSystemPlugin()
+{
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload;
+}
+
 const char* CCrySensorSystemPlugin::GetName() const
 {
 	return "CrySensorSystem";

--- a/Code/CryPlugins/CrySensorSystem/Module/CrySensorSystemPluginDLL.h
+++ b/Code/CryPlugins/CrySensorSystem/Module/CrySensorSystemPluginDLL.h
@@ -15,6 +15,7 @@ class CCrySensorSystemPlugin : public ICrySensorSystemPlugin
 
 	CRYGENERATE_SINGLETONCLASS(CCrySensorSystemPlugin, "Plugin_CrySensorSystem", 0x08a9684689334211, 0x913f7a64c0bf9822)
 
+	CCrySensorSystemPlugin();
 	virtual ~CCrySensorSystemPlugin() {}
 
 	// ICryPlugin

--- a/Code/CryPlugins/CryUserAnalytics/Module/CryUserAnalyticsDLL.cpp
+++ b/Code/CryPlugins/CryUserAnalytics/Module/CryUserAnalyticsDLL.cpp
@@ -10,6 +10,8 @@
 CPlugin_CryUserAnalytics::CPlugin_CryUserAnalytics()
 	: m_pUserAnalytics(nullptr)
 {
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload;
 }
 
 CPlugin_CryUserAnalytics::~CPlugin_CryUserAnalytics()

--- a/Code/CryPlugins/VR/CryOSVR/Module/PluginDll.cpp
+++ b/Code/CryPlugins/VR/CryOSVR/Module/PluginDll.cpp
@@ -15,6 +15,12 @@ namespace CryVR
 {
 namespace Osvr {
 
+CPlugin_Osvr::CPlugin_Osvr()
+{
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload;
+};
+
 CPlugin_Osvr::~CPlugin_Osvr()
 {
 	CryVR::Osvr::Resources::Shutdown();

--- a/Code/CryPlugins/VR/CryOSVR/Module/PluginDll.h
+++ b/Code/CryPlugins/VR/CryOSVR/Module/PluginDll.h
@@ -16,6 +16,7 @@ class CPlugin_Osvr : public IOsvrPlugin, public ISystemEventListener
 
 	CRYGENERATE_SINGLETONCLASS(CPlugin_Osvr, "Plugin_OSVR", 0x655D32522A6D4D09, 0xAFE82386D4566054)
 
+	CPlugin_Osvr();
 	virtual ~CPlugin_Osvr();
 
 	//! Retrieve name of plugin.

--- a/Code/CryPlugins/VR/CryOculusVR/Module/PluginDll.cpp
+++ b/Code/CryPlugins/VR/CryOculusVR/Module/PluginDll.cpp
@@ -22,6 +22,12 @@ namespace Oculus {
 	float CPlugin_OculusVR::s_hmd_projection_screen_dist = 1.0f;
 	int CPlugin_OculusVR::s_hmd_post_inject_camera = 0;
 
+CPlugin_OculusVR::CPlugin_OculusVR()
+{
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload;
+}
+
 CPlugin_OculusVR::~CPlugin_OculusVR()
 {
 	CryVR::Oculus::Resources::Shutdown();

--- a/Code/CryPlugins/VR/CryOculusVR/Module/PluginDll.h
+++ b/Code/CryPlugins/VR/CryOculusVR/Module/PluginDll.h
@@ -16,6 +16,7 @@ class CPlugin_OculusVR : public IOculusVRPlugin, public ISystemEventListener
 
 	CRYGENERATE_SINGLETONCLASS(CPlugin_OculusVR, "Plugin_OculusVR", 0x4DF8241E2BC24EC7, 0xB237EE5DB27265B3)
 
+	CPlugin_OculusVR();
 	virtual ~CPlugin_OculusVR();
 
 	//! Retrieve name of plugin.

--- a/Code/CryPlugins/VR/CryOpenVR/Module/PluginDll.cpp
+++ b/Code/CryPlugins/VR/CryOpenVR/Module/PluginDll.cpp
@@ -17,6 +17,12 @@ namespace OpenVR {
 	float CPlugin_OpenVR::s_hmd_quad_width = 1.0f;
 	int CPlugin_OpenVR::s_hmd_quad_absolute = 1;
 
+CPlugin_OpenVR::CPlugin_OpenVR()
+{
+	m_loadPriority = EPluginPriority_CryLoad;
+	m_unloadPriority = EPluginPriority_CryUnload;
+}
+
 CPlugin_OpenVR::~CPlugin_OpenVR()
 {
 	CryVR::OpenVR::Resources::Shutdown();

--- a/Code/CryPlugins/VR/CryOpenVR/Module/PluginDll.h
+++ b/Code/CryPlugins/VR/CryOpenVR/Module/PluginDll.h
@@ -16,6 +16,7 @@ class CPlugin_OpenVR : public IOpenVRPlugin, public ISystemEventListener
 
 	CRYGENERATE_SINGLETONCLASS(CPlugin_OpenVR, "Plugin_OpenVR", 0x50A54ADB4BBF4068, 0x80B9EB3BFFA30C93)
 
+	CPlugin_OpenVR();
 	virtual ~CPlugin_OpenVR();
 
 	//! Retrieve name of plugin.


### PR DESCRIPTION
So, since schematyc insisted on being loaded and unloaded in a very specific order, I looked into prototyping a plugin load/unload priority mechanism lol, if you want a read/my rudimentary implementation idea;

## [General Idea]
I opted to leave the ordering mostly to the coders, whilst initially separating system plugins from user (default) plugins, but allowing flexibility to override if need be.
Basically I just isolated the Initialize() method for the plugins away from the class instantiation, the plugins initialize in the order they arrive, but the ICryPlugin interface method to Initialize() is called in the order of the ICryPlugin Priorities (order of arrival if matching priority).

## [Implementation]
Simply added a couple int16s (m_loadPriority/m_unloadPriority) to the ICryPlugin class as protected friends to CryPluginManager.
Load/Unload creates a temp vector sorted by these values.

## [Details (Load)]
During load a temporary **vector<IcryPlugin*> containerPtrs** is created.
A range loop iterates over **m_pluginContainer**(s ?) and pushes a pointer into **containerPtrs** for each element.
Quick call to **std::set** via lambda results in a sorted list by **containerPtrs[n]->m_pPlugin->m_loadPriority**.
Another range loop iterates over **containerPtrs** and calls **containerPtrs[n]->m_pPlugin->Initialize(...)** on each element.
Then a quick **std::erase/remove** clears all the lements that failed to initialize by checking **containerPtrs[n]->m_bFailedInit**

## [Details (Unload)]
Again a temp vector **containerPtrs** is created.
Another range loop copies pointers to eachelement as before.
Now a **std::reverse** initially reverses the entire vector.
Then a quick sort (reverse of load sort) sorts everything by **containerPtrs[n]->m_pPlugin->m_unloadPriority**.

## [Modifications]
Had to modify Cryengine Plugins to include the necessary priorities in their plugin constructors.
Modified **SPluginContainer** to set **m_bFailedInit** on failed Initialization/null plugin ptr.
Specifically modified Schematyc plugins for special unload priorities. (this finally fixed my exit crash :P)
Also had to move intialization of **STDEnv** member pointers such as **m_pSystemStateMonitor** into the Initialize method.^^

^^ - The constructors in these classes assume Core is already Initalized. True in the default implementation as Init follows immediately after Instantiation.

## [Use Notes]
There is a new enum in **ICryPlugin** to help clarify and provide flexibility with priorities.
```	enum EPluginPriority : int16
	{
		EPluginPriority_CryUnload = -100,	// Lowest priority
		EPluginPriority_Default = 0,
		EPluginPriority_CryLoad = 100	// Highest priority
	};
```

All you have to do is put this in your plugin (**ICryPlugin** Inheritor) constructor:
```	m_loadPriority = EPluginPriority_Default;
	m_unloadPriority = EPluginPriority_Default;
```
	
Then in another plugin you can (un)load in you desired order:
```	m_loadPriority = EPluginPriority_Default-1; // Lower priority
	m_unloadPriority = EPluginPriority_Default+1; // Higher priority
```

----
It feels hackish ha, but I dunno gives a bit of freedom. Only reason I had to do this is because I didn't want to chase invalidated virtual pointers because schematyc unload wasnt just so xD. Maybe unnecessary in future builds anyway.