### PR TITLE
!BE (System) Translate x, y for mousewheel events

### DIFF
--- a/Code/CryEngine/CrySystem/System.cpp
+++ b/Code/CryEngine/CrySystem/System.cpp
@@ -3314,6 +3314,14 @@ bool CSystem::HandleMessage(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, 
 		break;
 	case WM_MOUSEWHEEL:
 		event = HARDWAREMOUSEEVENT_WHEEL;
+		{
+			POINT pt;
+			pt.x = x;
+			pt.y = y;
+			ScreenToClient(hWnd, &pt);
+			x = pt.x;
+			y = pt.y;
+		}
 		break;
 
 	// Any other event doesn't interest us


### PR DESCRIPTION
WM_MOUSEWHEEL will give x and y relative to the upper left corner of the screen (see https://msdn.microsoft.com/en-us/library/windows/desktop/ms645617(v=vs.85).aspx).
ScreenToClient is needed to translate these x/y values to those relative to the application (to be consistent with the other mouse events)