### PR TITLE
!XE (GamePlugin) Missing code block added for registering user defined EntityComponents.

### DIFF
--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AlembicComponent.cpp
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AlembicComponent.cpp
@@ -45,6 +45,24 @@ namespace Cry
 				pFunction->BindOutput(0, 'time', "Time");
 				componentScope.Register(pFunction);
 			}
+			{
+				auto pFunction = SCHEMATYC_MAKE_ENV_FUNCTION(&CAlembicComponent::Play, "{C91CB65E-4400-4382-A8C5-7C447A3A16E9}"_cry_guid, "Play");
+				pFunction->SetDescription("Plays the alembic animation");
+				pFunction->SetFlags(Schematyc::EEnvFunctionFlags::Construction);
+				componentScope.Register(pFunction);
+			}
+			{
+				auto pFunction = SCHEMATYC_MAKE_ENV_FUNCTION(&CAlembicComponent::Pause, "{34087A40-704B-44D4-A237-0F0A1EC34B69}"_cry_guid, "Pause");
+				pFunction->SetDescription("Pauses the alembic animation");
+				pFunction->SetFlags(Schematyc::EEnvFunctionFlags::Construction);
+				componentScope.Register(pFunction);
+			}
+			{
+				auto pFunction = SCHEMATYC_MAKE_ENV_FUNCTION(&CAlembicComponent::Stop, "{EC63B1C4-6A09-4F87-9B51-C1EA86EFC734}"_cry_guid, "Stop");
+				pFunction->SetDescription("Stops the alembic animation");
+				pFunction->SetFlags(Schematyc::EEnvFunctionFlags::Construction);
+				componentScope.Register(pFunction);
+			}
 		}
 
 		void CAlembicComponent::Initialize()
@@ -61,11 +79,18 @@ namespace Cry
 			{
 				Initialize();
 			}
+			else if (event.event == ENTITY_EVENT_UPDATE)
+			{
+				SetPlaybackTime(GetPlaybackTime() + m_playSpeed);
+			}
 		}
 
 		uint64 CAlembicComponent::GetEventMask() const
 		{
-			return BIT64(ENTITY_EVENT_COMPONENT_PROPERTY_CHANGED);
+			uint64 bitFlags = m_isPlayEnabled ? BIT64(ENTITY_EVENT_UPDATE) : 0;
+			bitFlags |= BIT64(ENTITY_EVENT_COMPONENT_PROPERTY_CHANGED);
+
+			return bitFlags;
 		}
 
 		void CAlembicComponent::Enable(bool bEnable)
@@ -115,6 +140,26 @@ namespace Cry
 		void CAlembicComponent::SetFilePath(const char* szFilePath)
 		{
 			m_filePath = szFilePath;
+		}
+
+		void CAlembicComponent::Play()
+		{
+			m_isPlayEnabled = true;
+			m_pEntity->UpdateComponentEventMask(this);
+		}
+
+		void CAlembicComponent::Pause()
+		{
+			m_isPlayEnabled = false;
+			m_pEntity->UpdateComponentEventMask(this);
+		}
+
+		void CAlembicComponent::Stop()
+		{
+			m_isPlayEnabled = false;
+			m_currentTime = 0.01f;
+			SetPlaybackTime(0.f);
+			m_pEntity->UpdateComponentEventMask(this);
 		}
 	}
 }

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AlembicComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AlembicComponent.h
@@ -41,6 +41,7 @@ namespace Cry
 				desc.SetComponentFlags({ IEntityComponent::EFlags::Transform, IEntityComponent::EFlags::Socket, IEntityComponent::EFlags::Attach });
 
 				desc.AddMember(&CAlembicComponent::m_filePath, 'file', "FilePath", "File", "Determines the geom cache file (abc / cbc) to load", "%ENGINE%/EngineAssets/GeomCaches/default.cbc");
+				desc.AddMember(&CAlembicComponent::m_playSpeed, 'pspd', "PlaySpeed", "Speed", "Determines the play speed of the animation", 0.005f);
 			}
 
 			virtual void Enable(bool bEnable);
@@ -53,8 +54,15 @@ namespace Cry
 			virtual void SetFilePath(const char* szFilePath);
 			const char* GetFilePath() const { return m_filePath.value.c_str(); }
 
+			virtual void Play();
+			virtual void Pause();
+			virtual void Stop();
+
 		protected:
 			Schematyc::GeomCacheFileName m_filePath;
+			bool m_isPlayEnabled = false;
+			float m_playSpeed = 0.005f;
+			float m_currentTime = 0.01f;
 		};
 	}
 }

--- a/Code/GameTemplates/cpp/Blank/Code/GamePlugin.cpp
+++ b/Code/GameTemplates/cpp/Blank/Code/GamePlugin.cpp
@@ -30,7 +30,30 @@ void CGamePlugin::OnSystemEvent(ESystemEvent event, UINT_PTR wparam, UINT_PTR lp
 {
 	switch (event)
 	{
-		// Called when the game framework has initialized and we are ready for game logic to start
+	case ESYSTEM_EVENT_REGISTER_SCHEMATYC_ENV:
+	{
+		// Register all components that belong to this plug-in
+		auto staticAutoRegisterLambda = [](Schematyc::IEnvRegistrar& registrar)
+		{
+			// Call all static callback registered with the CRY_STATIC_AUTO_REGISTER_WITH_PARAM
+			Detail::CStaticAutoRegistrar<Schematyc::IEnvRegistrar&>::InvokeStaticCallbacks(registrar);
+		};
+
+		if (gEnv->pSchematyc)
+		{
+			gEnv->pSchematyc->GetEnvRegistry().RegisterPackage(
+				stl::make_unique<Schematyc::CEnvPackage>(
+					GetSchematycPackageGUID(),
+					"EntityComponents",
+					"Crytek GmbH",
+					"Components",
+					staticAutoRegisterLambda
+					)
+			);
+		}
+	}
+	break;
+	// Called when the game framework has initialized and we are ready for game logic to start
 	case ESYSTEM_EVENT_GAME_POST_INIT:
 	{
 		// Don't need to load the map in editor

--- a/Code/GameTemplates/cpp/Blank/Code/GamePlugin.h
+++ b/Code/GameTemplates/cpp/Blank/Code/GamePlugin.h
@@ -27,6 +27,8 @@ public:
 	virtual bool Initialize(SSystemGlobalEnvironment& env, const SSystemInitParams& initParams) override;
 	virtual void OnPluginUpdate(EPluginUpdateType updateType) override {}
 	// ~ICryPlugin
+	
+	static CryGUID GetSchematycPackageGUID() { return "{FC9BD884-49DE-4494-9D64-191734BBB7E3}"_cry_guid; }
 
 	// ISystemEventListener
 	virtual void OnSystemEvent(ESystemEvent event, UINT_PTR wparam, UINT_PTR lparam) override;


### PR DESCRIPTION
There is an issue with registering user defined EntityComponents in Blank Project because of the missing code block in **GamePlugin**. Simply, they are not registered by the engine, even if they have the correct registration code blocks. This change adds the missing code block to GamePlugin for fixing that issue.

**Issue link:** https://github.com/CRYTEK/CRYENGINE/issues/235