### PR TITLE
!B (CryEntitySystem) Use FragmentID when referring to fragments

### DIFF
--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AdvancedAnimationComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AdvancedAnimationComponent.h
@@ -119,8 +119,8 @@ public:
 			return;
 		}
 
-		TagID fragmentId = m_pAnimationContext->controllerDef.m_fragmentIDs.Find(fragmentName.c_str());
-		if (fragmentId == TAG_ID_INVALID)
+		FragmentID fragmentId = m_pAnimationContext->controllerDef.m_fragmentIDs.Find(fragmentName.c_str());
+		if (fragmentId == FRAGMENT_ID_INVALID)
 		{
 			CryWarning(VALIDATOR_MODULE_GAME, VALIDATOR_ERROR, "Failed to find Mannequin fragment %s in controller definition %s", fragmentName.c_str(), m_pAnimationContext->controllerDef.m_filename.c_str());
 			return;


### PR DESCRIPTION
Change a use of TagID to FragmentID, I know they're typedef'd to each other but makes the code a bit easier to understand