### PR TITLE
Fix GetRandomUnitVector.

### DIFF
--- a/Code/CryEngine/CryCommon/CryMath/CryRandomInternal.h
+++ b/Code/CryEngine/CryCommon/CryMath/CryRandomInternal.h
@@ -136,12 +136,9 @@ inline VT GetRandomUnitVector(R& randomGenerator)
 	VT res;
 	T lenSquared;
 
-	do
-	{
-		res = BoundedRandomComponentwise<R, VT>::Get(randomGenerator, VT(-1), VT(1));
-		lenSquared = res.GetLengthSquared();
-	}
-	while (lenSquared > 1);
+	//TODO: replace by a spherical uniform distribution method.
+	res = BoundedRandomComponentwise<R, VT>::Get(randomGenerator, VT(-1), VT(1));
+	lenSquared = res.GetLengthSquared();
 
 	if (lenSquared >= (std::numeric_limits<T>::min)())
 	{

--- a/Code/CryEngine/CryCommon/CryMath/CryRandomInternal.h
+++ b/Code/CryEngine/CryCommon/CryMath/CryRandomInternal.h
@@ -142,7 +142,7 @@ inline VT GetRandomUnitVector(R& randomGenerator)
 
 	if (lenSquared >= (std::numeric_limits<T>::min)())
 	{
-		return res / isqrt_tpl(lenSquared);
+		return res * isqrt_tpl(lenSquared);
 	}
 
 	res = VT(ZERO);

--- a/Code/CryEngine/CryCommon/CryMath/CryRandomInternal.h
+++ b/Code/CryEngine/CryCommon/CryMath/CryRandomInternal.h
@@ -142,7 +142,7 @@ inline VT GetRandomUnitVector(R& randomGenerator)
 
 	if (lenSquared >= (std::numeric_limits<T>::min)())
 	{
-		return res * isqrt_tpl(lenSquared);
+		return res / isqrt_tpl(lenSquared);
 	}
 
 	res = VT(ZERO);


### PR DESCRIPTION
1. Fixed a little misprint in normalization.
2. Fixed non deterministic execution count of 
*res = BoundedRandomComponentwise<R, VT>::Get(randomGenerator, VT(-1), VT(1));*