### PR TITLE
!B (CryPhysX) Fix shutdown issues

### DIFF
--- a/Code/CryEngine/CryPhysicsSystem/CryPhysX/CryPhysX.cpp
+++ b/Code/CryEngine/CryPhysicsSystem/CryPhysX/CryPhysX.cpp
@@ -114,6 +114,7 @@ namespace cpx // CryPhysX helper
 		m_Cooking(nullptr),
 		m_Foundation(nullptr),
 		m_Physics(nullptr),
+		m_CpuDispatcher(nullptr),
 		m_PvdTransport(nullptr),
  		m_Pvd(nullptr),
 		m_DebugVisualizationForAllSceneElements(false)
@@ -170,7 +171,6 @@ namespace cpx // CryPhysX helper
 		m_Pvd = PxCreatePvd(*m_Foundation);
 		if (!m_Pvd)
 		{
-			fatalError("PxProfileZoneManager::createProfileZoneManager failed!");
 			fatalError("PxCreatePvd failed!");
 		}
 
@@ -202,17 +202,11 @@ namespace cpx // CryPhysX helper
 			unsigned int timeout = 10000;           // timeout in milliseconds to wait for PVD to respond,
  													// consoles and remote PCs need a higher timeout.
 			m_PvdTransport = PxDefaultPvdSocketTransportCreate(pvd_host_ip, port, timeout);
-			if (!m_PvdTransport)
- 				fatalError("PxDefaultPvdSocketTransportCreate failed!");
- 
+			if (!m_PvdTransport) fatalError("PxDefaultPvdSocketTransportCreate failed!");
+
 			// and now try to connect
 			m_Pvd->connect(*m_PvdTransport, PxPvdInstrumentationFlag::eALL);
- 
-			if (m_Pvd->isConnected()) 
-			{
- 				Helper::Log("PhysX Visual Debugger Connection - initialized.\n");
- 				m_Scene->getScenePvdClient()->setScenePvdFlag(PxPvdSceneFlag::eTRANSMIT_CONSTRAINTS, true);
-			}
+			if (m_Pvd->isConnected()) Helper::Log("PhysX Visual Debugger Connection - initialized.\n");
 		}
 #endif
 
@@ -220,9 +214,9 @@ namespace cpx // CryPhysX helper
 		const PxVec3 gravity = PxVec3(0.0f, 0.0f, -9.81f);
 
 		sceneDesc.gravity = gravity;
-		PxDefaultCpuDispatcher* mCpuDispatcher = PxDefaultCpuDispatcherCreate(noOfThreads);
-		if (!mCpuDispatcher) fatalError("PxDefaultCpuDispatcherCreate failed!");
-		sceneDesc.cpuDispatcher = mCpuDispatcher;
+		m_CpuDispatcher = PxDefaultCpuDispatcherCreate(noOfThreads);
+		if (!m_CpuDispatcher) fatalError("PxDefaultCpuDispatcherCreate failed!");
+		sceneDesc.cpuDispatcher = m_CpuDispatcher;
 		sceneDesc.filterShader = CollFilter;
 		sceneDesc.broadPhaseType = PxBroadPhaseType::eMBP;
 		sceneDesc.flags |= PxSceneFlag::eENABLE_CCD;
@@ -231,6 +225,8 @@ namespace cpx // CryPhysX helper
 
 		m_Scene = m_Physics->createScene(sceneDesc);
 		if (!m_Scene) fatalError("createScene failed!");
+
+		m_Scene->getScenePvdClient()->setScenePvdFlag(PxPvdSceneFlag::eTRANSMIT_CONSTRAINTS, true);
 
 		if (USE_PHYSX_DEBUGDRAW)
 		{
@@ -258,14 +254,13 @@ namespace cpx // CryPhysX helper
 	CryPhysX::~CryPhysX()
 	{
 		// shutdown PhysX
-		if (m_PvdTransport) m_PvdTransport->release();
-		m_Pvd->release();
 		PxCloseVehicleSDK();
 		m_Cooking->release();
 		m_Scene->release();
+		m_CpuDispatcher->release();
 		m_Physics->release();
-		if (m_PvdTransport) m_PvdTransport->release();
 		m_Pvd->release();
+		if (m_PvdTransport) m_PvdTransport->release();
 		PxCloseExtensions();
 		m_Foundation->release();
 	}
@@ -323,6 +318,10 @@ namespace cpx // CryPhysX helper
 		_SceneResetEntities(m_Scene, PxActorTypeFlag::eRIGID_DYNAMIC);
 	}
 
+	void CryPhysX::DisconnectPhysicsDebugger()
+	{
+		if (m_Pvd->isConnected()) m_Pvd->disconnect();
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/CryEngine/CryPhysicsSystem/CryPhysX/CryPhysX.h
+++ b/Code/CryEngine/CryPhysicsSystem/CryPhysX/CryPhysX.h
@@ -49,12 +49,14 @@ namespace cpx // CryPhysX
 		void SceneResetDynamicEntities();
 
 		void SetDebugVisualizationForAllSceneElements(bool enable = true);
+		void DisconnectPhysicsDebugger();
 
 	private:
 
 		float                             m_dt;
 
 		physx::PxPhysics*                 m_Physics;
+		physx::PxDefaultCpuDispatcher*    m_CpuDispatcher;
 		physx::PxFoundation*              m_Foundation;
 		physx::PxScene*                   m_Scene;
 		physx::PxCooking*                 m_Cooking;

--- a/Code/CryEngine/CryPhysicsSystem/CryPhysX/CryPhysics.cpp
+++ b/Code/CryEngine/CryPhysicsSystem/CryPhysX/CryPhysics.cpp
@@ -29,6 +29,10 @@ public:
 			break;
 		case ESYSTEM_EVENT_3D_POST_RENDERING_END:
 			break;
+		case ESYSTEM_EVENT_FAST_SHUTDOWN:
+		case ESYSTEM_EVENT_FULL_SHUTDOWN:
+			cpx::g_cryPhysX.DisconnectPhysicsDebugger();
+			break;
 		}
 	}
 };


### PR DESCRIPTION
Removed duplicate PhysX module releases. Added missing cpu dispatcher release as PhysX docs instruct to release all used modules and all their samples do this for cpu dispatcher as well.

setScenePvdFlag was moved after physics scene creation as it would crash on NPE otherwise.

Separately disconnected PVD on engine shutdown. Change was needed because on GameLauncher exit PVD module release would make the app crash if PVD was still connected. Crash was caused by PhysX trying to access internal resource that's already been removed.