### PR TITLE
!B (CryPhysics) Fix missing CryPhysX terrain collision in GameLauncher

### DIFF
--- a/Code/CryEngine/Cry3DEngine/terrain_compile.cpp
+++ b/Code/CryEngine/Cry3DEngine/terrain_compile.cpp
@@ -799,6 +799,9 @@ bool CTerrain::Load(FILE* f, int nDataSize, STerrainChunkHeader* pTerrainChunkHe
 			                       COMPILED_TERRAIN_TEXTURE_FILE_NAME, m_arrBaseTexInfos.m_ucpDiffTexTmpBuffer, m_arrBaseTexInfos.m_nDiffTexIndexTableSize);
 	}
 
+	// initialize heightfield for physics engines that can't stream the terrain data
+	InitHeightfieldPhysics();
+
 	return bRes;
 }
 


### PR DESCRIPTION
Solves https://github.com/CRYTEK/CRYENGINE/issues/305 .

When using CryPhysics, terrain data can be streamed in after heightmap initialization stage. With CryPhysX, steaming is not an option and data has to be available the moment you run the initialization. This PR fixes this by placing additional InitHeightfieldPhysics() after terrain has been loaded by the 3D engine.

As additional note, two InitHeightfieldPhysics function calls in terrain_compile.cpp and terrain_load.cpp make only 0 height terrain collision with CryPhysX and are not needed for it. They could be potentially removed but didn't remove them in this PR as I don't know all the side-effects when using stock CryPhysics. Those additional heightfield inits can be seen in this commit where I've manually commented them out: https://github.com/0lento/CRYENGINE/commit/bfc1c2aa1ccfc30b7e0d6f4edb69da9a9ce92dce