### PR TITLE
Added ability to queue an action

### DIFF
--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AdvancedAnimationComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Geometry/AdvancedAnimationComponent.h
@@ -148,6 +148,16 @@ public:
 		m_pActionController->Queue(*m_pActiveAction);
 	}
 
+	virtual void QueueAction(TAction<SAnimationContext>& pAction)
+	{
+		if (m_pAnimationContext == nullptr)
+		{
+			return;
+		}
+
+		m_pActionController->Queue(pAction);
+	}
+
 	// TODO: Expose resource selector for tags
 	virtual void SetTag(const Schematyc::CSharedString& tagName, bool bSet)
 	{


### PR DESCRIPTION
This commit adds a new method that allows the CAdvancedAnimation class to queue up actions that are created by code external to the class.

This allows you to keep the fragment handling code in TAction classes, and simply queue those up, without needing to expose the action controller.