### PR TITLE
!F (Default Entities) Added physically based light values

### DIFF
--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ILightComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ILightComponent.h
@@ -17,6 +17,14 @@ namespace DefaultComponents
 		ExcludeForGI = IRenderNode::EGIMode::eGM_HideIfGiIsActive,
 	};
 
+	// Used to change the light unit used to the brightness
+	enum class ELightUnit
+	{
+		Legacy = 0,
+		Lumen,
+		Candela
+	};
+
 	static void ReflectType(Schematyc::CTypeDesc<ELightGIMode>& desc)
 	{
 		desc.SetGUID("{2DC20597-A17E-4306-A023-B73A6FBDBB3D}"_cry_guid);
@@ -26,6 +34,17 @@ namespace DefaultComponents
 		desc.AddConstant(ELightGIMode::StaticLight, "StaticLight", "Static");
 		desc.AddConstant(ELightGIMode::DynamicLight, "DynamicLight", "Dynamic");
 		desc.AddConstant(ELightGIMode::ExcludeForGI, "ExcludeForGI", "Hide if GI is Active");
+	}
+
+	static void ReflectType(Schematyc::CTypeDesc<ELightUnit>& desc)
+	{
+		desc.SetGUID("{15856F2A-AF54-4B4E-9F38-C0C51B248A74}"_cry_guid);
+		desc.SetLabel("Light Intensity Unit");
+		desc.SetDescription("Changes the unit of light used");
+		desc.SetDefaultValue(ELightUnit::Legacy);
+		desc.AddConstant(ELightUnit::Legacy, "Legacy", "Legacy Intensity");
+		desc.AddConstant(ELightUnit::Lumen, "Lumen", "Lumen");
+		desc.AddConstant(ELightUnit::Candela, "Candela", "Candela");
 	}
 
 	struct ILightComponent : public IEntityComponent
@@ -52,7 +71,9 @@ namespace DefaultComponents
 			inline bool operator==(const SColor &rhs) const { return 0 == memcmp(this, &rhs, sizeof(rhs)); }
 
 			ColorF m_color = ColorF(1.f);
-			Schematyc::Range<0, 10000, 0, 100> m_diffuseMultiplier = 1.f;
+			Schematyc::Range<1000, 25000, 1000, 15000> m_temputure = 5500.0f;
+			ELightUnit m_lightUnit = ELightUnit::Legacy;
+			Schematyc::Range<0, 10000, 0, 10000> m_diffuseMultiplier = 1.f;
 			Schematyc::Range<0, 10000> m_specularMultiplier = 1.f;
 		};
 
@@ -89,6 +110,8 @@ namespace DefaultComponents
 
 	public:
 		virtual void SetOptics(const char* szFullOpticsName) = 0;
+		virtual ColorF GetColorFromTemperature(float temperature) = 0;
+		virtual float GetIntensity(float oldIntensity) = 0;
 
 		virtual void Enable(bool bEnable) = 0;
 		virtual bool IsEnabled() const { return m_bActive; }
@@ -144,6 +167,8 @@ namespace DefaultComponents
 	{
 		desc.SetGUID("{B71C3414-F85A-4EAA-9CE0-5110A2E040AD}"_cry_guid);
 		desc.AddMember(&ILightComponent::SColor::m_color, 'col', "Color", "Color", nullptr, ColorF(1.f));
+		desc.AddMember(&ILightComponent::SColor::m_temputure, 'tmp', "Temperature", "Temperature", nullptr, 5500.0f);
+		desc.AddMember(&ILightComponent::SColor::m_lightUnit, 'unt', "LightUnit", "Light Unit", nullptr, ELightUnit::Legacy);
 		desc.AddMember(&ILightComponent::SColor::m_diffuseMultiplier, 'diff', "DiffMult", "Diffuse Multiplier", nullptr, 1.f);
 		desc.AddMember(&ILightComponent::SColor::m_specularMultiplier, 'spec', "SpecMult", "Specular Multiplier", nullptr, 1.f);
 	}

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ILightComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ILightComponent.h
@@ -71,7 +71,7 @@ namespace DefaultComponents
 			inline bool operator==(const SColor &rhs) const { return 0 == memcmp(this, &rhs, sizeof(rhs)); }
 
 			ColorF m_color = ColorF(1.f);
-			Schematyc::Range<1000, 25000, 1000, 15000> m_temputure = 5500.0f;
+			Schematyc::Range<1000, 25000, 1000, 15000> m_temperature = 5500.0f;
 			ELightUnit m_lightUnit = ELightUnit::Legacy;
 			Schematyc::Range<0, 10000, 0, 10000> m_diffuseMultiplier = 1.f;
 			Schematyc::Range<0, 10000> m_specularMultiplier = 1.f;
@@ -167,7 +167,7 @@ namespace DefaultComponents
 	{
 		desc.SetGUID("{B71C3414-F85A-4EAA-9CE0-5110A2E040AD}"_cry_guid);
 		desc.AddMember(&ILightComponent::SColor::m_color, 'col', "Color", "Color", nullptr, ColorF(1.f));
-		desc.AddMember(&ILightComponent::SColor::m_temputure, 'tmp', "Temperature", "Temperature", nullptr, 5500.0f);
+		desc.AddMember(&ILightComponent::SColor::m_temperature, 'tmp', "Temperature", "Temperature", nullptr, 5500.0f);
 		desc.AddMember(&ILightComponent::SColor::m_lightUnit, 'unt', "LightUnit", "Light Unit", nullptr, ELightUnit::Legacy);
 		desc.AddMember(&ILightComponent::SColor::m_diffuseMultiplier, 'diff', "DiffMult", "Diffuse Multiplier", nullptr, 1.f);
 		desc.AddMember(&ILightComponent::SColor::m_specularMultiplier, 'spec', "SpecMult", "Specular Multiplier", nullptr, 1.f);

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/PointLightComponent.cpp
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/PointLightComponent.cpp
@@ -39,7 +39,7 @@ namespace Cry
 			light.m_Flags = DLF_DEFERRED_LIGHT | DLF_POINT;
 
 			float brightness = GetIntensity(m_color.m_diffuseMultiplier);
-			ColorF newLightColor = (m_color.m_color * brightness) * GetColorFromTemperature(m_color.m_temputure);
+			ColorF newLightColor = (m_color.m_color * brightness) * GetColorFromTemperature(m_color.m_temperature);
 
 			light.SetLightColor(newLightColor);
 			light.SetSpecularMult(m_color.m_specularMultiplier);

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/PointLightComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/PointLightComponent.h
@@ -47,6 +47,9 @@ namespace Cry
 				Initialize();
 			}
 
+			virtual ColorF GetColorFromTemperature(float temperature) override;
+			virtual float GetIntensity(float oldIntensity) override;
+
 			virtual void Enable(bool enable) override;
 
 			static void ReflectType(Schematyc::CTypeDesc<CPointLightComponent>& desc)

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ProjectorLightComponent.cpp
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ProjectorLightComponent.cpp
@@ -43,7 +43,10 @@ void CProjectorLightComponent::Initialize()
 	light.m_fLightFrustumAngle = m_angle.ToDegrees();
 	light.m_fProjectorNearPlane = m_projectorOptions.m_nearPlane;
 
-	light.SetLightColor(m_color.m_color * m_color.m_diffuseMultiplier);
+	float brightness = GetIntensity(m_color.m_diffuseMultiplier);
+	ColorF newLightColor = (m_color.m_color * brightness) * GetColorFromTemperature(m_color.m_temputure);
+
+	light.SetLightColor(newLightColor);
 	light.SetSpecularMult(m_color.m_specularMultiplier);
 
 	light.m_fHDRDynamic = 0.f;
@@ -213,6 +216,41 @@ void CProjectorLightComponent::ProcessEvent(const SEntityEvent& event)
 	if (event.event == ENTITY_EVENT_COMPONENT_PROPERTY_CHANGED || event.event == ENTITY_EVENT_LINK || event.event == ENTITY_EVENT_DELINK)
 	{
 		Initialize();
+	}
+}
+
+ColorF CProjectorLightComponent::GetColorFromTemperature(float temperature)
+{
+	float r, g, b;
+
+	float kelvin = crymath::clamp(temperature, 1000.0f, 10000.0f) / 1000.0f;
+	float kelvin2 = kelvin * kelvin;
+
+	r = kelvin < 6.570f ? 1.0f : crymath::clamp((1.35651f + 0.216422f * kelvin + 0.000633715f * kelvin2) / (-3.24223f + 0.918711f * kelvin), 0.0f, 1.0f);
+	g = kelvin < 6.570f
+		? crymath::clamp((-399.809f + 414.271f * kelvin + 111.543f * kelvin2) / (2779.24f + 164.143f * kelvin + 84.7356f * kelvin2), 0.0f, 1.0f)
+		: crymath::clamp((1370.38f + 734.616f * kelvin + 0.689955f * kelvin2) / (-4625.69f + 1699.87f * kelvin), 0.0f, 1.0f);
+	b = kelvin > 6.570f ? 1.0f : crymath::clamp((348.963f - 523.53f * kelvin + 183.62f * kelvin2) / (2848.82f - 214.52f * kelvin + 78.8614f * kelvin2), 0.0f, 1.0f);
+
+	return ColorF(r, g, b, 1.0f);
+
+}
+
+float CProjectorLightComponent::GetIntensity(float oldIntensity)
+{
+	if (m_color.m_lightUnit == ELightUnit::Legacy)
+	{
+		return oldIntensity;
+	}
+	else
+	{
+		float intensity = (oldIntensity * (2.0f * (1.0f - crymath::cos(m_angle.ToDegrees() / 2.0f)) * 3.141596) * 16.0f / (100.0f * 100.0f) / 3.141596);
+
+		if (m_color.m_lightUnit == ELightUnit::Candela)
+		{
+			intensity *= (2.0f * (1.0f - crymath::cos(m_angle.ToDegrees() / 2.0f)) * 3.141596);
+		}
+		return intensity;
 	}
 }
 

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ProjectorLightComponent.cpp
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ProjectorLightComponent.cpp
@@ -44,7 +44,7 @@ void CProjectorLightComponent::Initialize()
 	light.m_fProjectorNearPlane = m_projectorOptions.m_nearPlane;
 
 	float brightness = GetIntensity(m_color.m_diffuseMultiplier);
-	ColorF newLightColor = (m_color.m_color * brightness) * GetColorFromTemperature(m_color.m_temputure);
+	ColorF newLightColor = (m_color.m_color * brightness) * GetColorFromTemperature(m_color.m_temperature);
 
 	light.SetLightColor(newLightColor);
 	light.SetSpecularMult(m_color.m_specularMultiplier);

--- a/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ProjectorLightComponent.h
+++ b/Code/CryPlugins/CryDefaultEntities/Module/DefaultComponents/Lights/ProjectorLightComponent.h
@@ -48,6 +48,9 @@ namespace Cry
 				Initialize(); 
 			}
 
+			virtual ColorF GetColorFromTemperature(float temperature) override;
+			virtual float GetIntensity(float oldIntensity) override;
+
 			static void ReflectType(Schematyc::CTypeDesc<CProjectorLightComponent>& desc)
 			{
 				desc.SetGUID("{07D0CAD1-8E79-4177-9ADD-A2464A009FA5}"_cry_guid);


### PR DESCRIPTION
## Overview

This pull request adds Kelvin temperature for color and both Lumens and Candela for brightness. Currently it is set up to be used on both point lights and projector lights, each having a slightly different implementation for working out brightness making it correct with the light area its putting out.

## Showcase

![Kelvin Temperature](https://i.imgur.com/dxFiTzR.jpg "Kelvin Temperature")


![Brightness](https://i.imgur.com/iAMf5cj.jpg "Brightness")

## Limitations

The biggest limitation with the current implementation is that it doesn't take into account any area light values, larger area lights should give off more light for the same value. 

Another limitation is that there is a base cost for the Kelvin temperature at all times and then a further cost if you choose to use lumens or candela. It most cases I don't think it will be too noticeable but may affect performance when large numbers of lights are in use.