### PR TITLE
!BE (3DEngine) Fix objects not correctly rendering when e_streamInsta…

### DIFF
--- a/Code/CryEngine/Cry3DEngine/ObjectsTree.cpp
+++ b/Code/CryEngine/Cry3DEngine/ObjectsTree.cpp
@@ -2489,8 +2489,8 @@ COctreeNode::COctreeNode(const AABB& box, CVisArea* pVisArea, COctreeNode* pPare
 
 	m_vNodeCenter = box.GetCenter();
 	m_vNodeAxisRadius = box.GetSize() * 0.5f;
-	m_objectsBox.min = box.max;
-	m_objectsBox.max = box.min;
+	m_objectsBox.min = box.min;
+	m_objectsBox.max = box.max;
 
 #if !defined(_RELEASE)
 	// Check if bounding box is crazy


### PR DESCRIPTION
…nces is enabled.

There is a bug that when using `e_streamInstances` objects appear and then disappear again as you get closer to them. I discovered this behavior changed to the correct behavior after `C3DEngine::ProcessCVarsChange` is called, and then followed through the code to find and fix this issue.

Note: I've been testing this based on `main`, however I've created this PR based on `pullrequests`.