### PR TITLE
!BE (Sandbox) Fix transition editor only showing fragments on one scope

### DIFF
--- a/Code/Sandbox/EditorQt/Mannequin/Controls/TransitionEditorPage.cpp
+++ b/Code/Sandbox/EditorQt/Mannequin/Controls/TransitionEditorPage.cpp
@@ -721,7 +721,7 @@ float CTransitionEditorPage::PopulateClipTracks(CSequencerNode* node, const int 
 					uint32 rootScope = 0;
 					for (uint32 i = 0; i <= scopeID; i++)
 					{
-						if ((BIT64(1) & scopeMask) != 0)
+						if ((BIT64(i) & scopeMask) != 0)
 						{
 							rootScope = i;
 							break;


### PR DESCRIPTION
Previously only the first scope for a context would show any fragments, this allows all scopes to be showed correctly.