### PR TITLE
!B (RC) Fixed improper SZip library handling

### DIFF
--- a/Code/Libs/hdf5/CMakeLists.txt
+++ b/Code/Libs/hdf5/CMakeLists.txt
@@ -484,10 +484,12 @@ target_compile_options(${THIS_PROJECT} PRIVATE ${DISABLE_WARNINGS} ) # Disable w
 target_compile_definitions(${THIS_PROJECT} PRIVATE -D__STDC_VERSION__=199901L )
 target_link_libraries( ${THIS_PROJECT} PRIVATE zlib)
 if (HAVE_SZIP)
-	message(STATUS "Using SZIP")
+	message(STATUS "Enabled SZLib, increased performance.")
 	target_link_libraries( ${THIS_PROJECT} PRIVATE szip )
 	target_compile_definitions(${THIS_PROJECT} PRIVATE -DH5_HAVE_SZLIB_H=1 )
 	target_compile_definitions(${THIS_PROJECT} PRIVATE -DH5_HAVE_FILTER_SZIP=1 )
+else()
+	message(STATUS "Disabled SZLib. WARNING: Slower performance.")	
 endif()
 target_include_directories(${THIS_PROJECT} INTERFACE 
 	"${CMAKE_CURRENT_SOURCE_DIR}" # For the configuration files.

--- a/Code/Libs/hdf5/windows/H5pubconf.h
+++ b/Code/Libs/hdf5/windows/H5pubconf.h
@@ -106,8 +106,12 @@
 /* Define if support for deflate (zlib) filter is enabled */
 #define H5_HAVE_FILTER_DEFLATE 1
 
+/* PERSONAL CRYTEK: Now handled by the library CMake configuration file instead of harcoded here.*/
 /* Define if support for szip filter is enabled */
-#define H5_HAVE_FILTER_SZIP 1
+//#define H5_HAVE_FILTER_SZIP 1
+
+/* Define to 1 if you have the <szlib.h> header file. */
+//#define H5_HAVE_SZLIB_H 1
 
 /* Define to 1 if you have the `fork' function. */
 /* #undef H5_HAVE_FORK */
@@ -352,9 +356,6 @@
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define H5_HAVE_SYS_TYPES_H 1
-
-/* Define to 1 if you have the <szlib.h> header file. */
-#define H5_HAVE_SZLIB_H 1
 
 /* Define if we have thread safe support */
 /* #undef H5_HAVE_THREADSAFE */


### PR DESCRIPTION
Macro was hard-coded into the windows options as 'enabled'.

Obviously the cmake file should be handling compilation/building/etc.

Now works properly, and you can build RC without the slib library.

P.S: As requested, making a bijillion PR's.