### PR TITLE
!B (Renderer) Shader reset did not clear reflected buffer

### DIFF
--- a/Code/CryEngine/RenderDll/XRenderD3D9/DeviceManager/DeviceObjectHelpers.cpp
+++ b/Code/CryEngine/RenderDll/XRenderD3D9/DeviceManager/DeviceObjectHelpers.cpp
@@ -155,6 +155,10 @@ SDeviceObjectHelpers::CShaderConstantManager::CShaderConstantManager(CShaderCons
 void SDeviceObjectHelpers::CShaderConstantManager::Reset()
 {
 	m_constantBuffers.clear();
+
+	// PERSONAL CRYTEK: Otherwise when running ReleaseReflectedBuffers() it would die since 
+	// m_pShaderReflection->bufferCount > m_constantBuffers.size() and m_constantBuffers[i] would be invalid.....
+	m_pShaderReflection.reset();
 }
 
 bool SDeviceObjectHelpers::CShaderConstantManager::AllocateShaderReflection(::CShader* pShader, const CCryNameTSCRC& technique, uint64 rtFlags, EShaderStage shaderStages)


### PR DESCRIPTION
When Reset(), reflected buffer not cleared.

You can't have more reflected shaders than there are in the constant buffer.


P.S: As requested, making a bijillion PR's.