### PR TITLE
!B (Sandbox) Switching from mannequin layout to default view crash

### DIFF
--- a/Code/Sandbox/Plugins/EditorCommon/Timeline.cpp
+++ b/Code/Sandbox/Plugins/EditorCommon/Timeline.cpp
@@ -2124,11 +2124,14 @@ CTimeline::CTimeline(QWidget* parent)
 
 	m_highlightedTimer.setSingleShot(true);
 	m_highlightedConnection = QObject::connect(&m_highlightedTimer, &QTimer::timeout, [this]() { UpdateHightlightedInternal(); });
-	QObject::connect(this, &QObject::destroyed, [this]() { disconnect(m_highlightedConnection); });
 }
 
 CTimeline::~CTimeline()
 {
+	// PERSONAL CRYTEK: Fails in debug mode/build in standard engine.
+	// Moved from destroyed() bind to CTimeLine destructor.
+	// Reproducing: Build in debug, click 'mannequin' layout -> from that layout go to 'default' layout -> Sandbox crashes.
+	disconnect(m_highlightedConnection);
 }
 
 void CTimeline::customEvent(QEvent* pEvent)

--- a/Code/Sandbox/Plugins/EditorCommon/Timeline.cpp
+++ b/Code/Sandbox/Plugins/EditorCommon/Timeline.cpp
@@ -2128,9 +2128,6 @@ CTimeline::CTimeline(QWidget* parent)
 
 CTimeline::~CTimeline()
 {
-	// PERSONAL CRYTEK: Fails in debug mode/build in standard engine.
-	// Moved from destroyed() bind to CTimeLine destructor.
-	// Reproducing: Build in debug, click 'mannequin' layout -> from that layout go to 'default' layout -> Sandbox crashes.
 	disconnect(m_highlightedConnection);
 }
 


### PR DESCRIPTION
Reproduction: Build in debug, click 'mannequin' layout -> from that layout go to 'default' layout -> Sandbox crashes.

Just moved the destruction of QObject to CTimeLine destruction instead to follow similar setup in other classes.


P.S: As requested, making a bijillion PR's.