### PR TITLE
!B (Networking) Dedicated server assert for existing sub-mtl shaders

### DIFF
--- a/Code/CryEngine/Cry3DEngine/Material.cpp
+++ b/Code/CryEngine/Cry3DEngine/Material.cpp
@@ -477,7 +477,7 @@ void CMatInfo::SetSubMtl(int nSlot, IMaterial* pMtl)
 	if (pMtl)
 	{
 		const auto& shaderItem = pMtl->GetShaderItem();
-		CRY_ASSERT(shaderItem.m_pShader);
+		CRY_ASSERT(gEnv->IsDedicated() || shaderItem.m_pShader);
 		if (shaderItem.m_pShader && !!(shaderItem.m_pShader->GetFlags() & (EF_REFRACTIVE | EF_FORCEREFRACTIONUPDATE)))
 			SetFlags(GetFlags() | MTL_FLAG_REFRACTIVE);
 	}


### PR DESCRIPTION
Removed it, it will never be set cuz no renderer == no shaders.


P.S: As requested, making a bijillion PR's.