### PR TITLE
!B (Renderer) RenderNode invalid iterators

### DIFF
--- a/Code/CryEngine/Cry3DEngine/VisibleRenderNodeManager.cpp
+++ b/Code/CryEngine/Cry3DEngine/VisibleRenderNodeManager.cpp
@@ -212,12 +212,11 @@ void CVisibleRenderNodesManager::UpdateVisibleNodes(int currentFrame, int maxNod
 			m_firstAddedNode = -1;
 		}
 
-		auto b = m_visibleNodes.begin() + m_lastStartUpdateNode;
-		if (b >= m_visibleNodes.end())
-		{
-			b = m_visibleNodes.begin();
+		auto b = m_visibleNodes.begin();
+		if (m_lastStartUpdateNode >= m_visibleNodes.size())
 			m_lastStartUpdateNode = 0;
-		}
+		else
+			b += m_lastStartUpdateNode;
 
 		const auto maxFrames = (uint32)C3DEngine::GetCVars()->e_RNTmpDataPoolMaxFrames;
 		for (int i=0; i<maxNodesToCheck && b!=m_visibleNodes.end(); ++i)


### PR DESCRIPTION
m_lastStartUpdateNode handling == dies near instantly in launcher.

E.g. big sphere blocking view, shoot it to get it moving == dies

Debug mode engine btw.