### PR TITLE
!B (CrySystem) Removed m_lBaseTime adjustment and improved logging.

### DIFF
--- a/Code/CryEngine/CrySystem/System.cpp
+++ b/Code/CryEngine/CrySystem/System.cpp
@@ -3296,10 +3296,10 @@ void CSystem::SetSystemGlobalState(const ESystemGlobalState systemGlobalState)
 	{
 		if (gEnv && gEnv->pTimer)
 		{
-#if !defined(EXCLUDE_NORMAL_LOG)
 			const CTimeValue endTime = gEnv->pTimer->GetAsyncTime();
-			const float numSeconds = endTime.GetDifferenceInSeconds(s_startTime);
-#endif
+			float numSeconds = endTime.GetDifferenceInSeconds(s_startTime);
+			if (s_startTime == CTimeValue())
+				numSeconds = gEnv->pTimer->GetAsyncCurTime();				// Elapsed time since Reset, in this case system boot .-.
 			CryLog("SetGlobalState %d->%d '%s'->'%s' %3.1f seconds",
 				   m_systemGlobalState, systemGlobalState,
 				   CSystem::GetSystemGlobalStateName(m_systemGlobalState), CSystem::GetSystemGlobalStateName(systemGlobalState),

--- a/Code/CryEngine/CrySystem/Timer.cpp
+++ b/Code/CryEngine/CrySystem/Timer.cpp
@@ -359,7 +359,7 @@ void CTimer::UpdateOnFrameStart()
 		m_replicationTime += m_fFrameTime;
 
 	// Adjust the base time so that time actually seems to have moved forward m_fFrameTime
-	const int64 frameTicks = SecondsToTicks(m_fFrameTime);
+	/*const int64 frameTicks = SecondsToTicks(m_fFrameTime);
 	const int64 realTicks = SecondsToTicks(m_fRealFrameTime);
 	m_lBaseTime += realTicks - frameTicks;
 	if (m_lBaseTime > now)
@@ -367,10 +367,10 @@ void CTimer::UpdateOnFrameStart()
 		// Guard against rounding errors due to float <-> int64 precision
 		assert(m_lBaseTime - now <= 10 && "Bad base time or adjustment, too much difference for a rounding error");
 		m_lBaseTime = now;
-	}
+	}*/
 	const int64 currentTime = now - m_lBaseTime;
 
-	assert(fabsf(TicksToSeconds(currentTime - m_lLastTime) - m_fFrameTime) < 0.01f && "Bad calculation");
+	//assert(fabsf(TicksToSeconds(currentTime - m_lLastTime) - m_fFrameTime) < 0.01f && "Bad calculation");
 	assert(currentTime >= m_lLastTime && "Bad adjustment in previous frame");
 	assert(currentTime + m_lOffsetTime >= 0 && "Sum of game time is negative");
 

--- a/Code/CryEngine/CrySystem/XConsole.cpp
+++ b/Code/CryEngine/CrySystem/XConsole.cpp
@@ -2316,7 +2316,7 @@ ELoadConfigurationType CXConsole::SetCurrentConfigType(ELoadConfigurationType co
 
 void CXConsole::ExecuteCommand(CConsoleCommand& cmd, string& str, bool bIgnoreDevMode)
 {
-	CryLog("[CONSOLE] Executing console command '%s'", str.c_str());
+	CryLog("[CONSOLE] Executing console command '%s'. [%3.1f] seconds have passed since boot.", str.c_str(), (float)gEnv->pTimer->GetAsyncCurTime());
 	INDENT_LOG_DURING_SCOPE();
 
 	std::vector<string> args;


### PR DESCRIPTION
Easier to test server connection command + time between states early on.

Had to remove base-time adjustment, just like in my time edits.
Otherwise GetAsyncCurTime() is inconsistent, especially on boot.

time_smoothing unrelated to GetAsyncCurTime() issue, real culprit is base time offset.
