### PR TITLE
!B (Renderer) AABB Tree not initialized

### DIFF
--- a/Code/CryEngine/Cry3DEngine/VisAreaMan.cpp
+++ b/Code/CryEngine/Cry3DEngine/VisAreaMan.cpp
@@ -47,6 +47,9 @@ CVisAreaManager::CVisAreaManager()
 	m_segVisAreas.Clear();
 	m_segPortals.Clear();
 	m_segOcclAreas.Clear();
+	
+	// For Editor
+	InitAABBTree();
 }
 
 void CVisAreaManager::DeleteAllVisAreas()

--- a/Code/CryEngine/Cry3DEngine/VisAreaManCompile.cpp
+++ b/Code/CryEngine/Cry3DEngine/VisAreaManCompile.cpp
@@ -239,6 +239,8 @@ bool CVisAreaManager::Load_T(T*& f, int& nDataSize, SVisAreaManChunkHeader* pVis
 	m_pCurArea = m_pCurPortal = 0;
 	UpdateConnections();
 
+	InitAABBTree();
+
 	return nDataSize == 0;
 }
 


### PR DESCRIPTION
Due to this commit:
https://github.com/CRYTEK/CRYENGINE/commit/69737eae0113c09bbcf393105ae39fcf61ac828e

AABB Tree is no longer initialized/updated during GetVisAreaFromPos(), causing assert-crashes for me in Debug mode.

For some reason, InitAABTree() has never been used (that I can find).
m_pVisAreaManager->Load() actually deletes the AABB Tree twice, and it's never initialized again.

And Editor never creates/loads it before use.