### PR TITLE
Fix unordered_map call to lower_bound with find.

### DIFF
--- a/Code/CryEngine/RenderDll/XRenderD3D9/DeviceManager/DeviceObjects.cpp
+++ b/Code/CryEngine/RenderDll/XRenderD3D9/DeviceManager/DeviceObjects.cpp
@@ -369,7 +369,7 @@ const CDeviceObjectFactory::SInputLayoutPair* CDeviceObjectFactory::GetOrCreateI
 	// Create the composition descriptor
 	SInputLayoutCompositionDescriptor compositionDescriptor(VertexFormat, StreamMask, pShaderReflection);
 
-	auto it = s_InputLayoutCompositions.lower_bound(compositionDescriptor);
+	auto it = s_InputLayoutCompositions.find(compositionDescriptor);
 	if (it == s_InputLayoutCompositions.end() || it->first != compositionDescriptor)
 	{
 		// Create the input layout for the current permutation


### PR DESCRIPTION
In VS2019 Update 3 we will add a new warning to detect calls to unordered_Meow::lower_bound and unordered_Meow::upper_bound, because those do not exist in the standard. The new warning fires in CryEngine with output similar to the following. The fix is to change the call to lower_bound into a call to find, which is the standard spelling for that operation.

CryRenderD3D11_CryRenderer_uber_5.i
CryRenderD3D11_CryRenderer_uber_5.i(535631): error C2220: warning treated as error - no 'object' file generated
CryRenderD3D11_CryRenderer_uber_5.i(535631): warning C4996: 'std::_Hash<std::_Umap_traits<_Kty,_Ty,std::_Uhash_compare<_Kty,_Hasher,_Keyeq>,_Alloc,false>>::lower_bound': warning STL4022: The hash_meow and unordered_meow containers' non-Standard lower_bound() member was provided for interface compatibility with the ordered associative containers, and doesn't match the semantics of the hash_meow or unordered_meow containers. Please use the find() member instead. You can define _SILENCE_STDEXT_HASH_LOWER_BOUND_DEPRECATION_WARNING to suppress this deprecation.
        with
        [
            _Kty=SInputLayoutCompositionDescriptor,
            _Ty=CDeviceObjectFactory::SInputLayoutPair,
            _Hasher=SInputLayoutCompositionDescriptor::hasher,
            _Keyeq=std::equal_to<SInputLayoutCompositionDescriptor>,
            _Alloc=std::allocator<std::pair<const SInputLayoutCompositionDescriptor,CDeviceObjectFactory::SInputLayoutPair>>
        ]
CryRenderD3D11_CryRenderer_uber_5.i(114295): note: see declaration of 'std::_Hash<std::_Umap_traits<_Kty,_Ty,std::_Uhash_compare<_Kty,_Hasher,_Keyeq>,_Alloc,false>>::lower_bound'
        with
        [
            _Kty=SInputLayoutCompositionDescriptor,
            _Ty=CDeviceObjectFactory::SInputLayoutPair,
            _Hasher=SInputLayoutCompositionDescriptor::hasher,
            _Keyeq=std::equal_to<SInputLayoutCompositionDescriptor>,
            _Alloc=std::allocator<std::pair<const SInputLayoutCompositionDescriptor,CDeviceObjectFactory::SInputLayoutPair>>
        ]