### PR TITLE
!T Ignore qpOASES warnings to build physics

### DIFF
--- a/Code/CryEngine/CryPhysics/articulatedentity.cpp
+++ b/Code/CryEngine/CryPhysics/articulatedentity.cpp
@@ -13,7 +13,15 @@
 #include "physicalworld.h"
 #include "rigidentity.h"
 #include "articulatedentity.h"
-#include "qpOASES.hpp"
+
+// TODO: Temporarily ignoring __FUNC__ override conflict with qpOASES, fix.
+// Plus ignoring 'hidden' functions.
+#pragma warning(push)
+	#pragma warning(disable:4005)
+	#pragma warning(disable:4266)
+	#pragma warning(disable:4264)
+	#include "qpOASES.hpp"
+#pragma warning(pop)
 
 typedef Vec3_tpl<qpOASES::real_t> Vec3qp;
 


### PR DESCRIPTION
About macro conflicts/hidden functions...

Not sure how you're building with these? Different SDK version?

If so please let me know which one. I just pulled from [www.qpoases.org/go/release](url)
