### PR TITLE
!B (Animation) Bad check for loading causing heap corruption

### DIFF
--- a/Code/CryEngine/CryAnimation/CharacterManager.cpp
+++ b/Code/CryEngine/CryAnimation/CharacterManager.cpp
@@ -3534,10 +3534,8 @@ void CharacterManager::LoadAnimationImageFile(const char* filenameCAF, const cha
 {
 	CRY_PROFILE_FUNCTION(PROFILE_LOADING_ONLY);
 
-	if ((m_IMGLoadedFlags & EIMGLoadedFlags::IMGLoaded) == EIMGLoadedFlags::None)
-	{
+	if (m_IMGLoadedFlags != EIMGLoadedFlags::None)
 		return;
-	}
 
 	m_IMGLoadedFlags |= EIMGLoadedFlags::IMGLoaded;
 


### PR DESCRIPTION
Several types of 'loaded' possible, should be checking for just zero here/etc.
Either way this stops corrupting heap and what not.

I believe Claudio is aware of this post discord chat
One of his older commits caused the issue.