### PR TITLE
!X (CryWaf) Fix Resizing Problem

### DIFF
--- a/Code/Tools/waf-1.7.13/crywaflib/gui_tasks.py
+++ b/Code/Tools/waf-1.7.13/crywaflib/gui_tasks.py
@@ -886,7 +886,6 @@ class ThreadedGuiMenu(threading.Thread):
 		# Add handlers		
 		self.log_handler.attach()
 		self.root.wait_visibility()
-		self.root.resizable(0, 0)
 		self.gui_up = True
 		
 		# Run mainloop


### PR DESCRIPTION
Resizing is restricted and window is started with a weird geometry so it was unusable. It may create lots of exceptional cases, like the situation. Resizing is also controlled on the create_gui function so I just removed it.