### PR TITLE
Fix compiler warnings/errors caused by std::pow(float, int)

### DIFF
--- a/Code/CryEngine/CryFlowGraph/FlowSystem/Nodes/FlowInterpolNodes.cpp
+++ b/Code/CryEngine/CryFlowGraph/FlowSystem/Nodes/FlowInterpolNodes.cpp
@@ -54,7 +54,7 @@ float Linear(float ratio)
 
 float QuadIn(float ratio)
 {
-	return pow(ratio, 2);
+	return static_cast<float>(pow(ratio, 2));
 }
 
 float QuadOut(float ratio)
@@ -76,7 +76,7 @@ float QuadInOut(float ratio)
 
 float CubicIn(float ratio)
 {
-	return pow(ratio, 3);
+	return static_cast<float>(pow(ratio, 3));
 }
 
 float CubicOut(float ratio)
@@ -93,13 +93,13 @@ float CubicInOut(float ratio)
 	else
 	{
 		float factor = (2.0f * ratio - 2.0f);
-		return (ratio - 1.0f) * pow(factor, 2) + 1.0f;
+		return (ratio - 1.0f) * static_cast<float>(pow(factor, 2)) + 1.0f;
 	}
 }
 
 float QuartIn(float ratio)
 {
-	return pow(ratio, 4);
+	return static_cast<float>(pow(ratio, 4));
 }
 
 float QuartOut(float ratio)
@@ -121,7 +121,7 @@ float QuartInOut(float ratio)
 
 float QuintIn(float ratio)
 {
-	return pow(ratio, 5);
+	return static_cast<float>(pow(ratio, 5));
 }
 
 float QuintOut(float ratio)
@@ -227,7 +227,7 @@ float BounceOut(float ratio)
 {
 	const float length = 2.75f;
 	const float touchdown[3] = { 1.0f / length, 2.0f / length, 2.5f / length };
-	const float amplitude = pow(length, 2);
+	const float amplitude = static_cast<float>(pow(length, 2));
 	const float offsets[3] = { 1.5f / length, 2.25f / length, 2.625f / length };
 
 	if (ratio < touchdown[0])

--- a/Code/CryEngine/CryMovie/SceneNode.cpp
+++ b/Code/CryEngine/CryMovie/SceneNode.cpp
@@ -570,7 +570,7 @@ void CAnimSceneNode::ApplyCameraKey(SCameraKey& key, SAnimContext& animContext)
 	{
 		float t = 1 - ((nextKey.m_time - animContext.time).ToFloat() / key.m_blendTime);
 		t = min(t, 1.0f);
-		t = pow(t, 3) * (t * (t * 6 - 15) + 10);
+		t = static_cast<float>(pow(t, 3)) * (t * (t * 6 - 15) + 10);
 
 		// FOV
 		float fSecondCameraFOV = kDefaultCameraFOV;

--- a/Code/CryEngine/CrySystem/LocalizedStringManager.cpp
+++ b/Code/CryEngine/CrySystem/LocalizedStringManager.cpp
@@ -2481,7 +2481,7 @@ void CLocalizedStringsManager::LocalizeNumber(float number, int decimals, string
 
 	float decimalsOnly = f - (float)d;
 
-	int decimalsAsInt = int_round(decimalsOnly * pow(10.0f, decimals));
+	int decimalsAsInt = int_round(decimalsOnly * static_cast<float>(pow(10.0f, decimals)));
 
 	CryFixedStringT<64> tmp;
 	tmp.Format("%s%s%0*d", intPart.c_str(), commaSeparator.c_str(), decimals, decimalsAsInt);

--- a/Code/CryEngine/RenderDll/Common/RendElements/IrisShafts.cpp
+++ b/Code/CryEngine/RenderDll/Common/RendElements/IrisShafts.cpp
@@ -228,7 +228,7 @@ bool IrisShafts::PreparePrimitives(const SPreparePrimitivesContext& context)
 			m_fAngleRange = 0.65f * occ * occ + 0.35f;
 			m_fPrimaryDir = occQuery->GetDirResult() / (2 * PI);
 			m_fConcentrationBoost = 2.0f - occ;
-			m_fBrightnessBoost = 1 + 2 * pow(occ - 1, 6);
+			m_fBrightnessBoost = 1 + 2 * static_cast<float>(pow(occ - 1, 6));
 
 			m_meshDirty = true;
 			m_fPrevOcc = occ;
@@ -236,7 +236,7 @@ bool IrisShafts::PreparePrimitives(const SPreparePrimitivesContext& context)
 		else if (occ < 0.05f)
 		{
 			m_fAngleRange = 0.33f;
-			m_fBrightnessBoost = 1 + 2 * pow(interpOcc - 1, 6);
+			m_fBrightnessBoost = 1 + 2 * static_cast<float>(pow(interpOcc - 1, 6));
 			m_fPrevOcc = 0;
 			m_meshDirty = true;
 		}

--- a/Code/GameSDK/GameDll/GameRulesModules/GameRulesKingOfTheHillObjective.cpp
+++ b/Code/GameSDK/GameDll/GameRulesModules/GameRulesKingOfTheHillObjective.cpp
@@ -776,7 +776,7 @@ void CGameRulesKingOfTheHillObjective::OnOwnClientEnteredGame()
 float CGameRulesKingOfTheHillObjective::CalculateScoreTimer( int playerCount )
 {
 	float timerLength = m_scoreTimerMaxLength;
-	timerLength *= pow(m_scoreTimerAdditionalPlayerMultiplier, playerCount - 1);
+	timerLength *= static_cast<float>(pow(m_scoreTimerAdditionalPlayerMultiplier, playerCount - 1));
 	return timerLength;
 }
 

--- a/Code/Tools/CryCommonTools/StealingThreadPool.cpp
+++ b/Code/Tools/CryCommonTools/StealingThreadPool.cpp
@@ -388,7 +388,7 @@ static int ColorizeJobTrace(const ThreadUtils::JobTrace& trace)
 	const int numColors = sizeof(g_animColors) / sizeof(g_animColors[0]);
 	const int initialThread = trace.m_job.m_debugInitialThread;
 	const int index = initialThread % numColors;
-	const float brightness = pow(0.5f, initialThread / numColors);
+	const float brightness = static_cast<float>(pow(0.5f, initialThread / numColors));
 	return InterpolateColor(0, InterpolateColor(g_animColors[index], 0xffffff, 0.5f), brightness);
 }
 

--- a/Code/Tools/RC/ResourceCompilerPC/LodGenerator/AutoGenerator.cpp
+++ b/Code/Tools/RC/ResourceCompilerPC/LodGenerator/AutoGenerator.cpp
@@ -76,7 +76,7 @@ namespace LODGenerator
 			{
 				RCLog("Add Lod %d Percent:%f",i,fOriginPercent);
 				int index = i + 1;
-				float percent = pow(fOriginPercent,index);
+				float percent = static_cast<float>(pow(fOriginPercent,index));
 
 				for (int i=0;i<m_NodeLodInfoList[node].size();i++)
 				{


### PR DESCRIPTION
I work on Visual C++'s implementation of the C++ Standard Library. We regularly build CRYENGINE with development builds of our compiler and library, which allows us to find and fix bugs before they can get into shipping builds and affect customers like you. :smile_cat: This also allows us to provide advance notice of source-breaking changes. We recently merged a change to `std::pow` that will break CRYENGINE's build due to new compiler warnings being emitted (and treated as errors). I believe this PR should fix most or all of these warnings without affecting the behavior of the code, although I haven't attempted to build and test CRYENGINE.

We changed `std::pow` in https://github.com/microsoft/STL/pull/903 to conform to C++11's specification (better late than never), which affects the return type. In particular, `std::pow(float, int)` previously returned `float` and now returns `double`. This can trigger compiler warnings about truncation when assigning the result to a `float` variable, for example:

```
CRYENGINE/Code/CryEngine/CryFlowGraph/FlowSystem/Nodes/FlowInterpolNodes.cpp(57,12):
warning C4244: 'return': conversion from 'double' to 'float', possible loss of data
```

The fix is simple: Use `static_cast<float>` to explicitly convert the returned `double`. I've inserted these casts immediately around each affected `std::pow` call, so that the precision of any other computations in an expression isn't affected.

This PR contains two commits. One should fix every occurrence of compiler warnings found by our automated build. The second fixes a couple more occurrences that I found by inspecting every `pow` call in the codebase, looking for `pow(float, int)` specifically.

This change to `std::pow` will ship in Visual Studio 2019 version 16.8 Preview 1. Note that the `static_cast<float>` changes are backwards-compatible - they have literally no effect for previous builds of the library where `pow(float, int)` returned `float`.